### PR TITLE
Feat(wasse): vendure categories and global font-size

### DIFF
--- a/clients/wasse/.env
+++ b/clients/wasse/.env
@@ -1,2 +1,2 @@
-GRIDSOME_VENDURE_API=
-GRIDSOME_VENDURE_TOKEN=
+GRIDSOME_VENDURE_API=https://wkw-test.pinelab.studio/shop-api
+GRIDSOME_VENDURE_TOKEN=wkw-default

--- a/clients/wasse/gridsome.server.js
+++ b/clients/wasse/gridsome.server.js
@@ -24,7 +24,6 @@ module.exports = async function (api) {
     // TODO for every collection set prefix
 
     const collections = vendureServer.unflatten(allCollections);
-    console.log(collections);
     const navbarCollections = collections
       .filter((col) => col.name !== 'highlights')
       .map(mapToMinimalCollection);

--- a/clients/wasse/gridsome.server.js
+++ b/clients/wasse/gridsome.server.js
@@ -1,10 +1,46 @@
+const {
+  VendureServer,
+  SearchUtil,
+  deduplicate,
+} = require('pinelab-storefront');
+const { GraphQLClient } = require('graphql-request');
+const { mapToMinimalCollection } = require('./util');
+
 module.exports = async function (api) {
   api.createPages(async ({ createPage }) => {
+    const vendureServer = new VendureServer(
+      process.env.GRIDSOME_VENDURE_API,
+      process.env.GRIDSOME_VENDURE_TOKEN
+    );
+
+    const {
+      // Vendure content
+      products: allProducts,
+      availableCountries,
+      collections: allCollections,
+      productsPerCollection,
+    } = await vendureServer.getShopData();
+
+    // TODO for every collection set prefix
+
+    const collections = vendureServer.unflatten(allCollections);
+    console.log(collections);
+    const navbarCollections = collections
+      .filter((col) => col.name !== 'highlights')
+      .map(mapToMinimalCollection);
+
+    const global = {
+      navbarCollections,
+      categorySlugPrefix: 'product-categorie',
+    };
+
     // -------------------- Home -----------------------------------
     createPage({
       path: '/',
       component: './src/templates/Index.vue',
-      context: {},
+      context: {
+        ...global,
+      },
     });
   });
 };

--- a/clients/wasse/package.json
+++ b/clients/wasse/package.json
@@ -13,6 +13,7 @@
     "@gridsome/plugin-sitemap": "^0.4.0",
     "buefy": "^0.9.7",
     "debounce": "^1.2.1",
+    "fuse.js": "^6.6.2",
     "pinelab-storefront": "0.60.1"
   },
   "devDependencies": {

--- a/clients/wasse/src/components/AppHeader.vue
+++ b/clients/wasse/src/components/AppHeader.vue
@@ -53,12 +53,13 @@
           id="navbar-items-wrapper"
           class="container is-widescreen section is-hidden-mobile p-0"
         >
-          <template v-for="collection in collections">
+          <template v-for="collection in collections.slice(0, 4)">
             <template
               v-if="collection.children && collection.children.length > 0"
             >
+              <!-- Collection with child collections -->
               <div class="navbar-item has-dropdown is-hoverable shadow">
-                <g-link :to="collection.slug" class="navbar-link is-arrowless">
+                <g-link :to="collection.slug" class="navbar-link">
                   {{ collection.name }}
                 </g-link>
                 <div class="navbar-dropdown">
@@ -79,6 +80,7 @@
               </div>
             </template>
             <template v-else>
+              <!-- Collection without child collections -->
               <div class="navbar-item is-hoverable shadow">
                 <g-link :to="collection.slug" class="navbar-link is-arrowless">
                   {{ collection.name }}
@@ -86,6 +88,41 @@
               </div>
             </template>
           </template>
+          <!-- Overflow collections -->
+          <div class="navbar-item has-dropdown is-hoverable shadow">
+            <a class="navbar-link"> Meer </a>
+            <div class="navbar-dropdown">
+              <div class="container section py-1">
+                <div class="columns has-text-left">
+                  <div class="column">
+                    <template v-for="collection in collections.slice(4, 20)">
+                      <g-link to="/" class="navbar-item px-0">
+                        {{ collection.name }}
+                      </g-link>
+                    </template>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="navbar-item has-dropdown is-hoverable shadow">
+            <a class="navbar-link"> Informatie </a>
+            <div class="navbar-dropdown">
+              <div class="container section py-1">
+                <div class="columns has-text-left">
+                  <div class="column">
+                    <g-link to="/" class="navbar-item px-0">
+                      Advies en informatie
+                    </g-link>
+                    <g-link to="/" class="navbar-item px-0"> FAQ </g-link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="navbar-item is-hoverable shadow">
+            <g-link to="/" class="navbar-link is-arrowless"> Contact </g-link>
+          </div>
         </div>
       </div>
     </div>

--- a/clients/wasse/src/components/AppHeader.vue
+++ b/clients/wasse/src/components/AppHeader.vue
@@ -53,21 +53,38 @@
           id="navbar-items-wrapper"
           class="container is-widescreen section is-hidden-mobile p-0"
         >
-          <template v-for="index in 8">
-            <div class="navbar-item has-dropdown is-hoverable shadow">
-              <g-link to="/" class="navbar-link is-arrowless"> Wormen </g-link>
-              <div class="navbar-dropdown">
-                <div class="container section py-1">
-                  <div class="columns has-text-left">
-                    <div class="column">
-                      <template v-for="index in 5">
-                        <g-link to="/" class="navbar-item px-0"> TEST </g-link>
-                      </template>
+          <template v-for="collection in collections">
+            <template
+              v-if="collection.children && collection.children.length > 0"
+            >
+              <div class="navbar-item has-dropdown is-hoverable shadow">
+                <g-link :to="collection.slug" class="navbar-link is-arrowless">
+                  {{ collection.name }}
+                </g-link>
+                <div class="navbar-dropdown">
+                  <div class="container section py-1">
+                    <div class="columns has-text-left">
+                      <div class="column">
+                        <template
+                          v-for="childCollection in collection.children"
+                        >
+                          <g-link to="/" class="navbar-item px-0">
+                            {{ childCollection.name }}
+                          </g-link>
+                        </template>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-            </div>
+            </template>
+            <template v-else>
+              <div class="navbar-item is-hoverable shadow">
+                <g-link :to="collection.slug" class="navbar-link is-arrowless">
+                  {{ collection.name }}
+                </g-link>
+              </div>
+            </template>
           </template>
         </div>
       </div>
@@ -78,7 +95,7 @@
 
 <script>
 export default {
-  props: [],
+  props: ['collections'],
   components: {},
 };
 </script>

--- a/clients/wasse/src/components/AppHeader.vue
+++ b/clients/wasse/src/components/AppHeader.vue
@@ -105,6 +105,7 @@
               </div>
             </div>
           </div>
+          <!-- Non-collection navigation items -->
           <div class="navbar-item has-dropdown is-hoverable shadow">
             <a class="navbar-link"> Informatie </a>
             <div class="navbar-dropdown">

--- a/clients/wasse/src/layouts/DefaultLayout.vue
+++ b/clients/wasse/src/layouts/DefaultLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <AppHeader />
+    <AppHeader :collections="$context.navbarCollections" />
     <div class="container is-widescreen section p-2 pt-5">
       <slot />
     </div>

--- a/clients/wasse/src/theme.scss
+++ b/clients/wasse/src/theme.scss
@@ -29,6 +29,7 @@ $notification-radius: 0px;
 
 $navbar-item-hover-background-color: $primary;
 $navbar-dropdown-item-hover-color: $white;
+$navbar-dropdown-arrow: $white;
 
 // Setup $colors to use as bulma classes (e.g. 'is-twitter')
 $colors: mergeColorMaps(
@@ -102,6 +103,16 @@ $link-focus-border: $primary;*/
 // Import Bulma and Buefy styles
 @import '~bulma';
 @import '~buefy/src/scss/buefy';
+
+html {
+  font-size: 12px;
+  @include tablet {
+    font-size: 16px;
+  }
+  @include desktop {
+    font-size: 14px;
+  }
+}
 
 .button {
   @extend .is-primary;
@@ -177,16 +188,6 @@ h4 {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-}
-
-html {
-  font-size: 12px;
-  @include tablet {
-    font-size: 16px;
-  }
-  @include desktop {
-    font-size: 20px;
-  }
 }
 
 #banner {
@@ -266,4 +267,11 @@ img {
   background-color: $primary;
   border-top: 0px;
   color: $white;
+  font-size: 12px;
+  @include tablet {
+    font-size: 16px;
+  }
+  @include desktop {
+    font-size: 14px;
+  }
 }

--- a/clients/wasse/util.js
+++ b/clients/wasse/util.js
@@ -1,0 +1,17 @@
+module.exports = {
+  /**
+   * Optimizes a collection for menu display to save KB size
+   */
+  mapToMinimalCollection: function mapToMinimalCollection(col) {
+    return {
+      id: col.id,
+      slug: col.slug,
+      name: col.name,
+      featuredAsset: col.featuredAsset,
+      parent: col.parent ? mapToMinimalCollection(col.parent) : undefined,
+      children: col.children
+        ? col.children.map(mapToMinimalCollection)
+        : undefined,
+    };
+  },
+};

--- a/clients/wasse/yarn.lock
+++ b/clients/wasse/yarn.lock
@@ -4306,6 +4306,11 @@ functions-have-names@^1.2.2:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+fuse.js@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
+  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
* Categorien worden opgehaald uit Vendure
* Eerste 4 categorieen worden getoond, de rest onder "meer" ivm met de ruimte
* Lettertype aangepast naar 14px op desktop, was erg groot (paste ook maar 3 categorieen in de header)

![image](https://user-images.githubusercontent.com/6604455/196617377-6cd34555-613c-456b-991a-72bcd3ce6471.png)
