### PR TITLE
Feat/sendcloud csv parser

### DIFF
--- a/vendure/src/sendcloud/sendcloud-csv-parser.plugin.ts
+++ b/vendure/src/sendcloud/sendcloud-csv-parser.plugin.ts
@@ -1,0 +1,25 @@
+import { PluginCommonModule, VendurePlugin } from '@vendure/core';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+
+@Controller('sendcloud-csv-parser')
+export class SendcloudCsvParserController {
+  constructor() {}
+
+  @Get('/')
+  async download(@Query('csv') csvUrl: string) {
+    console.log('INCOMING', csvUrl);
+  }
+}
+
+/**
+ * This plugin takes the URL of a CSV export from Sendcloud,
+ * and parses all items from the CSV, calculates the sum of its quantities and returns a new CSV
+ * ( It actually does nothing with Vendure... )
+ * @example
+ * http://localhost:3000/sendcloud-csv-parser?csv=https://s3-eu-central-1.amazonaws.com/somepublicurl
+ */
+@VendurePlugin({
+  imports: [PluginCommonModule],
+  controllers: [SendcloudCsvParserController],
+})
+export class SendcloudCsvParserPlugin {}

--- a/vendure/src/sendcloud/sendcloud-csv-parser.plugin.ts
+++ b/vendure/src/sendcloud/sendcloud-csv-parser.plugin.ts
@@ -1,13 +1,57 @@
 import { PluginCommonModule, VendurePlugin } from '@vendure/core';
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import { Controller, Get, Param, Query, Res } from '@nestjs/common';
+import fetch from 'node-fetch';
+import { Response } from 'express';
+import * as Papa from 'papaparse';
 
+/**
+ * 1. Copy link from SendCloud email
+ * 2. Go to https://www.urlencoder.org/ and encode the url
+ * 3. In your browser, type `http://localhost:3000/sendcloud-csv-parser?csv=<encoded url>`
+ */
 @Controller('sendcloud-csv-parser')
 export class SendcloudCsvParserController {
   constructor() {}
 
   @Get('/')
-  async download(@Query('csv') csvUrl: string) {
-    console.log('INCOMING', csvUrl);
+  async download(@Query('csv') csvUrl: string, @Res() res: Response) {
+    const csvRes = await fetch(csvUrl);
+    if (!csvRes.ok) {
+      return res.status(csvRes.status).send(await csvRes.text());
+    }
+    const csvString = await csvRes.text();
+    const csvData = await this.parse(csvString);
+    const totalItems = new Map<string, number>();
+    // Loop all rows of the CSV
+    for (const row of csvData) {
+      const itemString = row['parcel items' as any];
+      if (!itemString) {
+        continue;
+      }
+      const items = JSON.parse(itemString);
+      // Loop each over parcel_item
+      items.forEach((item: any) => {
+        let amount = totalItems.get(item.description) || 0;
+        amount += item.quantity;
+        totalItems.set(item.description, amount);
+      });
+    }
+    let responseCsvString = '';
+    totalItems.forEach((amount, description) => {
+      responseCsvString += `"${description}": ${amount}<br>`;
+    });
+    return res.send(responseCsvString);
+  }
+
+  parse(csvString: string): Promise<any[]> {
+    return new Promise((resolve) => {
+      Papa.parse(csvString, {
+        header: true,
+        complete: function (results) {
+          resolve(results.data);
+        },
+      });
+    });
   }
 }
 

--- a/vendure/src/vendure-config.ts
+++ b/vendure/src/vendure-config.ts
@@ -58,6 +58,7 @@ import { ProductsSoldExportStrategy } from './export/products-sold-export-strate
 import { CouponsUsedExportStrategy } from './export/coupons-used-export-strategy';
 import { MetricsPlugin } from 'vendure-plugin-metrics';
 import { TaxPerCountryExportStrategy } from './export/tax-per-country-export-strategy';
+import { SendcloudCsvParserPlugin } from './sendcloud/sendcloud-csv-parser.plugin';
 
 let logger: VendureLogger;
 export let runningLocal = false;
@@ -213,6 +214,7 @@ export const config: VendureConfig = {
     ],
   },
   plugins: [
+    SendcloudCsvParserPlugin,
     VariantBulkUpdatePlugin,
     LimitVariantPerOrderPlugin,
     MetricsPlugin,


### PR DESCRIPTION
# Description

Added endpoint to Vendure so that Frank(wkw) can download a parsed version of the SendCloud csv export.

1. Copy the signed S3 link, encode it via https://www.urlencoder.org/
2. Use the encoded url as query parameter: `/sendcloud-csv-parser?csv=https%3A%2F%...`
3. The browser should give you a list with total quantities per item

# Screenshots

![image](https://github.com/Pinelab-studio/shops/assets/6604455/68ef6029-f043-48e9-8021-6d1b4fddae7f)

# Checklist

Please make sure you've done the following checks:

- [x] I have set a clear title
- [x] My PR is small and contains only a single feature. (Split into multiple PR's if needed)
- [x] I have added or updated test cases for important functionality
- [x] I have updated the README if needed
- [x] I have reviewed my own PR
- [x] I have fixed all typo's and have removed unused or commented code
