### PR TITLE
fix(vendure): request context patch

### DIFF
--- a/vendure/src/index.ts
+++ b/vendure/src/index.ts
@@ -1,5 +1,10 @@
 require('dotenv').config({ path: process.env.ENV_FILE });
-import { bootstrap, JobQueueService, Logger } from '@vendure/core';
+import {
+  bootstrap,
+  JobQueueService,
+  Logger,
+  RequestContextCacheService,
+} from '@vendure/core';
 import { INestApplication } from '@nestjs/common';
 import { config, runningInWorker, runningLocal } from './vendure-config';
 
@@ -14,6 +19,24 @@ bootstrap(config)
     }
     Logger.info(`Bootstrapped Vendure for env ${process.env.SHOP_ENV}`);
     app = _app;
+
+    // FIXME: Dirty hack to avoid caching of wrong 'activeTaxZone'. This patch makes sure get() never returns anything for activeTaxZone
+    // This is due to a wrong cache setting in Vendure core. The commit below (v2.2.0) should fix this issue:
+    // https://github.com/vendure-ecommerce/vendure/commit/e543e5e7006140518be311bc7e60687bd9b40778
+    // Next block should be removed when upgraded to v2.2.0
+    const requestContextCache = app.get(RequestContextCacheService);
+    const originalGet = requestContextCache.get;
+    requestContextCache.get = function (ctx, key, getDefault?: any) {
+      if (key === 'activeTaxZone') {
+        return getDefault?.();
+      } else {
+        return originalGet.call(requestContextCache, ctx, key, getDefault);
+      }
+    };
+    Logger.error(
+      `FIXME: remove this after v2.2.0: Patched RequestContextCacheService.get() to avoid caching of wrong 'activeTaxZone'`
+    );
+    // End of ugly patch block
   })
   .catch((err) => {
     console.error(err);

--- a/vendure/src/tax/shipping-based-tax-zone.strategy.ts
+++ b/vendure/src/tax/shipping-based-tax-zone.strategy.ts
@@ -18,20 +18,6 @@ export class ShippingBasedTaxZoneStrategy implements TaxZoneStrategy {
     channel: Channel,
     order?: Order
   ): Zone {
-    // FIXME: Dirty hack to avoid caching of wrong 'activeTaxZone'. This patch makes sure get() never returns anything for activeTaxZone
-    // This is due to a wrong cache setting in Vendure core. The commit below (v2.2.0) should fix this issue:
-    // https://github.com/vendure-ecommerce/vendure/commit/e543e5e7006140518be311bc7e60687bd9b40778
-    // Next block should be removed when upgraded to v2.2.0
-    // const requestContextCache = app.get(RequestContextCacheService);
-    // const originalGet = requestContextCache.get;
-    // requestContextCache.get = function (ctx, key, getDefault?: any) {
-    //   if (key === 'activeTaxZone') {
-    //     return getDefault?.();
-    //   } else {
-    //     return originalGet.call(requestContextCache, ctx, key, getDefault);
-    //   }
-    // }; // End of ugly patch block
-
     const countryCode = order?.shippingAddress?.countryCode;
     if (order && countryCode) {
       const zone = zones.find((zone) =>


### PR DESCRIPTION
# Description

Dirty hack to avoid caching of wrong 'activeTaxZone'. This patch makes sure get() never returns anything for activeTaxZone
    // This is due to a wrong cache setting in Vendure core. The commit below (v2.2.0) should fix this issue:
    // https://github.com/vendure-ecommerce/vendure/commit/e543e5e7006140518be311bc7e60687bd9b40778
    // Next block should be removed when upgraded to v2.2.0

# Checklist

📌 Always:
- [ ] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
