### PR TITLE
Feat/link local package + postalcode check for WKW

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,21 +8,20 @@ This repository holds all components needed to run the Pinelab Shops multi-tenan
 * `vendure` the Vendure backend.
 * `clients/*` holds the client specific storefronts
 * `packages/e2e` e2e test to test basic functionality on minishop.studio demo shop
-* `packages/pinelab-storefront` Frontend library used in all webshop frontends based on Buefy (Bulma)
+* `packages/pinelab-storefront` Frontend library used in all storefronts, based on Buefy (Bulma)
 
 ## Storefront Development
 
 1. Run `nvm use 16`, because Gridsome depends on node 16 unfortunately
 2. Run `yarn` in the root of the project
-3. Run `yarn bootstrap` to build all dependencies
-4. Go to `clients/wkw` for example, and run `yarn gridsome develop` to start the wormenkwekerijwasse.nl storefront locally. It will fetch data from the deployed Vendure instance.
+3. Run `yarn bootstrap` in the root to build all dependencies
+5. Go to `clients/wkw` for example, and run `yarn gridsome develop` to start the wormenkwekerijwasse.nl storefront locally. It will fetch data from the deployed Vendure instance.
 
 
 ### `packages/pinelab-storefront` development
-:warning: Most of the checkout for all clients is packaged in `packages/pinelab-storefront`. Whenever you need to develop something in that package, before publishing, follow these steps:
+:warning: Most of the checkout for all clients is packaged in `packages/pinelab-storefront`. To develop in that package with live reloading, run the following:
 
-1. Run `yarn dev` inside a clients directory. This will link `packages/pinelab-storefront` to the client project you are working on
-2. Whenever you change anything in `packages/pinelab-storefront/src/*` it will be rebuild
-3. After merging your PR, you need to checkout `master` and run `yarn lerna:publish` to publish `pinelab-storefront` and install it in all client projects in `clients/*`
+1. Run `yarn watch` inside `packages/pinelab-storefront`. This will recompile the pinelab-storefront files
+2. Run `yarn gridsome develop` like you normally would in one of the `clients/*` folders. This will use the compile files from `packages/pinelab-storefront/lib/*`
 
 :warning: Changes to `pinelab-storefront` will affect all clients!

--- a/clients/bendeboef/package.json
+++ b/clients/bendeboef/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ben-de-boef",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "yarn link-there && yarn link-here && concurrently \"cd ../../packages/pinelab-storefront && yarn watch\" \"gridsome develop\"",
     "link-here": "yarn link pinelab-storefront",
@@ -14,7 +14,7 @@
     "buefy": "^0.9.5",
     "debounce": "^1.2.1",
     "graphql-request": "^5.0.0",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "^1.16.1"
   },
   "devDependencies": {

--- a/clients/cantastic/package.json
+++ b/clients/cantastic/package.json
@@ -17,7 +17,7 @@
     "debounce": "^1.2.1",
     "fuse.js": "^6.6.2",
     "graphql-request": "^4.3.0",
-    "pinelab-storefront": "1.4.0"
+    "pinelab-storefront": "1.4.1"
   },
   "devDependencies": {
     "@gridsome/plugin-sitemap": "^0.4.0",
@@ -32,7 +32,7 @@
     "snapdragon-util": "^5.0.1",
     "webpack-bundle-analyzer": "^4.4.1"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "resolutions": {
     "graphql": "15.3.0"
   }

--- a/clients/cryptherion/package.json
+++ b/clients/cryptherion/package.json
@@ -14,7 +14,7 @@
     "@gridsome/plugin-sitemap": "^0.4.0",
     "buefy": "^0.9.14",
     "debounce": "^1.2.1",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "^1.16.1"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "sass": "^1.32.13",
     "sass-loader": "^10.1.1"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "resolutions": {
     "graphql": "^14.7.0"
   }

--- a/clients/danielvdhaterd/package.json
+++ b/clients/danielvdhaterd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "danielvdhaterd",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "serve": "yarn gridsome develop",
     "serve:static": "yarn concurrently \"nodemon --ext js,vue --watch '.src/' --exec 'yarn gridsome build && yarn http-server ./dist/'\""
@@ -14,7 +14,7 @@
     "buefy": "^0.9.22",
     "debounce": "^1.2.1",
     "graphql-request": "3.4.0",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "^1.16.1"
   },
   "devDependencies": {

--- a/clients/lab07/package.json
+++ b/clients/lab07/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lab07",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "dev": "yarn link-there && yarn link-here && concurrently \"cd ../../packages/pinelab-storefront && yarn watch\" \"gridsome develop\"",
     "link-here": "yarn link pinelab-storefront",
@@ -14,7 +14,7 @@
     "bulma": "^0.9.4",
     "debounce": "1.2.1",
     "graphql-request": "4.3.0",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "1.16.1"
   },
   "devDependencies": {

--- a/clients/op/package.json
+++ b/clients/op/package.json
@@ -13,7 +13,7 @@
     "@gridsome/plugin-sitemap": "^0.4.0",
     "buefy": "^0.9.14",
     "debounce": "^1.2.1",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "^1.16.1"
   },
   "devDependencies": {
@@ -26,7 +26,7 @@
     "sass": "^1.32.13",
     "sass-loader": "^10.1.1"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "resolutions": {
     "graphql": "^14.7.0"
   }

--- a/clients/royschreuder/package.json
+++ b/clients/royschreuder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "royschreuder",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "scripts": {
     "serve": "yarn gridsome develop",
     "serve:static": "yarn concurrently \"nodemon --ext js,vue --watch '.src/' --exec 'yarn gridsome build && yarn http-server ./dist/'\""
@@ -14,7 +14,7 @@
     "buefy": "^0.9.22",
     "debounce": "^1.2.1",
     "graphql-request": "3.4.0",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "^1.16.1"
   },
   "devDependencies": {

--- a/clients/super-a/package.json
+++ b/clients/super-a/package.json
@@ -14,7 +14,7 @@
     "debounce": "^1.2.1",
     "fuse.js": "^6.6.2",
     "graphql-request": "^4.3.0",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "1.4.1",
     "vue-gtag": "^1.16.1"
   },
   "devDependencies": {
@@ -27,7 +27,7 @@
     "sass-loader": "^10.1.1",
     "snapdragon-util": "^5.0.1"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "resolutions": {
     "graphql": "15.3.0"
   }

--- a/clients/wkw/package.json
+++ b/clients/wkw/package.json
@@ -18,7 +18,7 @@
     "debounce": "^1.2.1",
     "fuse.js": "^6.6.2",
     "graphql-tag": "^2.12.6",
-    "pinelab-storefront": "1.4.0",
+    "pinelab-storefront": "link:../../packages/pinelab-storefront",
     "vue-disqus": "4.X",
     "vue-gtag": "1.X"
   },

--- a/clients/wkw/package.json
+++ b/clients/wkw/package.json
@@ -5,10 +5,7 @@
     "serve:static": "yarn concurrently \"nodemon --ext js,vue --watch '.src/' --exec 'yarn gridsome build && yarn http-server ./dist/'\"",
     "serve:test": "export VENDURE_ENV=test && yarn gridsome develop",
     "serve:local": "export VENDURE_ENV=local && yarn gridsome develop",
-    "dev": "yarn link-there && yarn link-here && concurrently \"cd ../../packages/pinelab-storefront && yarn watch\" \"gridsome develop\"",
-    "dev:local": "export VENDURE_ENV=local && yarn link-there && yarn link-here && concurrently \"cd ../../packages/pinelab-storefront && yarn watch\" \"gridsome develop\"",
-    "link-here": "yarn link pinelab-storefront",
-    "link-there": "cd ../../packages/pinelab-storefront && yarn link"
+    "build": "cd ../../packages/pinelab-storefront && yarn build && cd ../../clients/wkw && yarn gridsome build"
   },
   "dependencies": {
     "@fontsource/poppins": "^4.5.10",

--- a/clients/wkw/package.json
+++ b/clients/wkw/package.json
@@ -32,7 +32,7 @@
     "sass": "^1.32.13",
     "sass-loader": "^10.1.1"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "resolutions": {
     "graphql": "^14.7.0"
   }

--- a/clients/wkw/yarn.lock
+++ b/clients/wkw/yarn.lock
@@ -7045,14 +7045,9 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pinelab-storefront@1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pinelab-storefront/-/pinelab-storefront-1.2.1.tgz#ec564a6e8f07e79802c0fccf10e50204a639cae2"
-  integrity sha512-WJfzPDXlor7ssn64C3QAcl0oSEaA0k4LjmJq3XQHB8jKhLi4r1yz3dAunU4XnO2/z8mjvDHorZ5HUEneNrYhxA==
-  dependencies:
-    graphql "15.3.0"
-    graphql-request "^3.4.0"
-    mitt "^3.0.0"
+"pinelab-storefront@link:../../packages/pinelab-storefront":
+  version "0.0.0"
+  uid ""
 
 pinkie-promise@^2.0.0:
   version "2.0.1"

--- a/lerna.json
+++ b/lerna.json
@@ -1,7 +1,7 @@
 {
   "npmClient": "yarn",
   "useWorkspaces": false,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "packages": [
     "packages/*",
     "clients/*",

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "e2e",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.js",
   "license": "MIT",
   "private": true,

--- a/packages/pinelab-storefront/package.json
+++ b/packages/pinelab-storefront/package.json
@@ -14,11 +14,10 @@
     "README.md"
   ],
   "scripts": {
-    "build": "rm -rf lib && yarn tsc --build && yarn copy",
-    "dev-build": "yarn tsc --build && yarn copy",
+    "build": "yarn tsc --build && yarn copy",
     "copy": "copyfiles -u 1 'src/components/**/*' 'src/pages/**/*' lib",
     "generate": "graphql-codegen",
-    "watch": "nodemon --verbose --ext js,ts,vue --watch ./src --exec 'yarn dev-build'",
+    "watch": "nodemon --verbose --ext js,ts,vue --watch ./src --exec 'yarn build'",
     "test": "jest"
   },
   "devDependencies": {

--- a/packages/pinelab-storefront/package.json
+++ b/packages/pinelab-storefront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinelab-storefront",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Vendure helpers and Vue components for the Pinelab e-commerce storefronts",
   "author": "Martijn van de Brug <martijn@pinelab.studio>",
   "homepage": "https://pinelab.studio",

--- a/packages/seo-migration/package.json
+++ b/packages/seo-migration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seo-migration",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Migration tool for checking redirect urls between old and new site",
   "main": "index.js",
   "license": "MIT",

--- a/vendure/package.json
+++ b/vendure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shops-vendure-backend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "start": "node ./dist/index",


### PR DESCRIPTION
# Description

* WKW storefront now uses the local compiled pinelab-storefront instead of a published version. The goal is that storefronts always use the up-to-date files from the repo, even if the package is not published. Once this is done for all storefronts we dont need publishing at all anymore.
* Added extra postalcode regex for NL postalcodes

# Breaking changes

Confirmation is blocked if postalcode is incorrect

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases for important functionality
- [ ] I have updated the README if needed

📦 For publishable packages:
- [ ] I have [increased the version number](## "After increasing the version to the next patch/minor/major, the package will be published automatically after merge") in `package.json`
- [ ] I have added my changes to the `CHANGELOG.md` [See this example](https://github.com/Pinelab-studio/pinelab-vendure-plugins/blob/main/packages/vendure-plugin-invoices/CHANGELOG.md)
